### PR TITLE
前后端合并测试

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -398,3 +398,101 @@ physics组件的实现
 #### Test
 
 1. 前端完成动画测试
+
+
+
+
+
+### 提交12
+
+#### Issue
+
+1、后端websocket仍然没法正确处理消息发送
+2、后端物理世界需要进行深拷贝
+
+#### Work
+
+1、前端组件新增Component和Shape，更好的使用继承关系处理方法
+2、前端的轨道和三角进行重新绘制，原因是没办发旋转图片
+3、后端的physical的一些信息进行修改（主要是调整了常量的位置）
+4、后端的websocket进行了调试和Game的创建
+
+#### Description
+
+更新
+
+全部前端组件js文件
+vuex存储文件
+switchBar.vue
+GameDesignBar.vue
+
+后端Physics文件夹
+game.java和Websocket.java
+新增
+
+1. GizmoComponent.js
+2. GizmoShape.js
+
+#### Test
+
+1.完成了前端显示测试
+2.完成了后端打印测试
+
+
+
+
+
+### 提交13
+
+#### Issue
+
+现在问题很多，总结下来下一阶段分工如下：
+
+文件类
+
+- 前端界面上没有保存导出的按钮，需要完成保存和导入（dyh，GameDesign.js）
+  - 按钮需要在游戏模式禁用，只有布局模式可以保存和导入
+  - 保存和导入需要和后端结合
+- 前端js导入文件信息初始化布局（dyh,LayoutView.vue)
+- 前端js的构造函数的修改（dyh,所有有旋转类的js）
+- 后端打开文件传入信息（yy,FileController,FileService,WebSocket)
+
+物理类
+
+- 后端组件黑洞(Blackhole)、挡板(Baffle)、轨道(StraightPipe,BendPipe)没实现（wxt）
+  - ![image-20221122175344354](http://typora-yy.oss-cn-hangzhou.aliyuncs.com/img/image-20221122175344354.png)
+- 后端组件的球体、三角形、正方体的放大、旋转有问题（wxt，yy）
+  - 旋转后会穿模![image-20221122175525641](http://typora-yy.oss-cn-hangzhou.aliyuncs.com/img/image-20221122175525641.png)
+- 三角型的初始化角度
+- 后端组件的toString方法重构
+  - Ball的toString方法（我已经改好了，yy)
+  - Baffle的toString方法（wxt）
+- worldManager清空（wxt）
+- WorldManager获得单独一个球，两个挡板（左挡板，右挡板）
+
+#### Work
+
+- 重构了WebSocketServer.java和Game.js统一了前后端的坐标衡量
+- 添加了前端Websocket获取信息的部分
+
+#### Description
+
+更新
+
+GameDesignBar.vue
+
+后端Physics文件夹
+game.java和Websocket.java
+
+WorldPlace.java
+
+上传了
+
+1. GizmoComponent.js
+2. GizmoShape.js
+
+#### Test
+
+完成了测试
+
+但是仍然有问题

--- a/backend/src/main/java/com/example/backend/consumer/WebSocketServer.java
+++ b/backend/src/main/java/com/example/backend/consumer/WebSocketServer.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 
 
-
 /**
  * 前后端建立连接通信
  * 发送消息，后端实时判断信息并完成渲染
@@ -31,31 +30,49 @@ public class WebSocketServer {
 
     private final WorldManager worldManager = new WorldManager();
 
+    //启动游戏
     private void startGame() {
-        game = new Game(worldManager);
+        game = new Game(this, worldManager);
         game.start();
     }
-
+    //结束游戏
     private void endGame() {
-
+        game.setDone(true);
     }
 
+    //载入布局
     private void initLayout() {
         //包装好的world需要实现toString方法
         sendMessage(worldManager.toString());
     }
 
+    //开启连接
     @OnOpen
     public void onOpen(Session session) {
         this.session = session;
         System.out.println("connected");
     }
 
+    //关闭连接
     @OnClose
     public void onClose(Session session) {
         System.out.println("disconnected");
     }
 
+    /**
+     * 接受消息
+     * 分为几类消息：
+     * 开启游戏 startGame
+     * 关闭游戏 endGame
+     * 添加组件 add
+     * 删除组件 delete
+     * 旋转组件 rotate
+     * 放大组件 magnify
+     * 缩小组件 shrink
+     * @param message 接受到的消息
+     * @param session websocket的session信息
+     * @throws IOException
+     */
     @OnMessage
     public void onMessage(String message, Session session) throws IOException {
         System.out.println("received " + message);
@@ -63,25 +80,11 @@ public class WebSocketServer {
 
         if ("startGame".equals(message)) {
             startGame();
-        } else if ("layoutMode".equalsIgnoreCase(message)) {
+        } else if ("endGame".equalsIgnoreCase(message)) {
             endGame();
             initLayout();
         } else if (message.startsWith("add")) {
-            String[] messages = message.split(" ");
-            String type = messages[1];
-            int id = Integer.parseInt(messages[2]);
-            float x = Float.parseFloat(messages[3]) * WorldConstant.LENGTH;
-            float y = Float.parseFloat(messages[4]) * WorldConstant.LENGTH;
-            Class<?> objectType;
-            try {
-                objectType = Class.forName("com.example.backend.physics.objs.Gizmo" + type);
-                Constructor<?> constructor = objectType.getConstructor(Integer.class, Float.class, Float.class);
-                GizmoObject object = (GizmoObject) constructor.newInstance(id, x, y);
-                worldManager.add(object);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-
+            addComponents(message);
         } else if (message.startsWith("delete")) {
             String[] messages = message.split(" ");
             int id = Integer.parseInt(messages[1]);
@@ -104,10 +107,33 @@ public class WebSocketServer {
         } else {
             throw new MessageException("websocket信息处理错误");
         }
-//        for (GizmoObject object : worldManager.getAll()) {
-//            System.out.println(object.toString());
-//        }
+    }
 
+    /**
+     * 添加组件（因为逻辑复杂单独分离出一个私有函数）
+     * @param message
+     */
+    private void addComponents(String message) {
+        String[] messages = message.split(" ");
+        //类型
+        String type = messages[1];
+        //组件的id
+        int id = Integer.parseInt(messages[2]);
+        //组件的横坐标
+        float x = Float.parseFloat(messages[3]) * WorldConstant.LENGTH;
+        //组件的纵坐标，因为物理引擎和画布上下颠倒，所以需要使用画布高度减当前的坐标
+        float y = WorldConstant.HIGHT - Float.parseFloat(messages[4]) * WorldConstant.LENGTH;
+        System.out.println(x + "" + y);
+        Class<?> objectType;
+        try {
+            //反射动态创建组件
+            objectType = Class.forName("com.example.backend.physics.objs.Gizmo" + type);
+            Constructor<?> constructor = objectType.getConstructor(Integer.class, Float.class, Float.class);
+            GizmoObject object = (GizmoObject) constructor.newInstance(id, x, y);
+            worldManager.add(object);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
 
@@ -116,6 +142,10 @@ public class WebSocketServer {
         error.printStackTrace();
     }
 
+    /**
+     * 向前端发送消息
+     * @param message 输出的消息
+     */
     public void sendMessage(String message) {
         try {
             this.session.getBasicRemote().sendText(message);

--- a/backend/src/main/java/com/example/backend/consumer/utils/Game.java
+++ b/backend/src/main/java/com/example/backend/consumer/utils/Game.java
@@ -1,5 +1,6 @@
 package com.example.backend.consumer.utils;
 
+import com.example.backend.consumer.WebSocketServer;
 import com.example.backend.physics.WorldManager;
 import com.example.backend.physicsInterface.GizmoObject;
 
@@ -7,13 +8,15 @@ public class Game extends Thread {
     private final Integer rows;
     private final Integer cols;
     private final WorldManager world;
+    private final WebSocketServer socketServer;
     private boolean isDone;
 
-    public Game(WorldManager initWorld) {
+    public Game(WebSocketServer socket,WorldManager initWorld) {
         rows = 20;
         cols = 20;
         world = initWorld;
         isDone = false;
+        socketServer = socket;
         initWorld.awakeAll();
     }
 
@@ -21,10 +24,18 @@ public class Game extends Thread {
     public void run() {
         super.run();
         while(!isDone){
-            for (GizmoObject objects: world.getAll()) {
-                world.logic();
-                System.out.println(objects.toString());
+            try {
+                Thread.sleep(30);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
             }
+            world.logic();
+            world.getAllBalls().forEach(e-> System.out.println(e.toString()));
+            world.getAllBalls().forEach(e-> socketServer.sendMessage(e.toString()));
         }
+    }
+
+    public void setDone(boolean done) {
+        isDone = done;
     }
 }

--- a/backend/src/main/java/com/example/backend/physics/WorldConstant.java
+++ b/backend/src/main/java/com/example/backend/physics/WorldConstant.java
@@ -4,6 +4,6 @@ public class WorldConstant {
     public static final int WIDTH = 800;
     public static final int HIGHT = 800;
     public static final float RATE = 10f;
-    public static final int LENGTH = 20;
+    public static final float LENGTH = 40.0f;
     public static final float TIME_STEP = 1f/30f;
 }

--- a/backend/src/main/java/com/example/backend/physics/WorldPlace.java
+++ b/backend/src/main/java/com/example/backend/physics/WorldPlace.java
@@ -31,7 +31,7 @@ public class WorldPlace {
     }
 
     public static void step(){
-        world.step(WorldConstant.TIME_STEP,6,6);
+            world.step(WorldConstant.TIME_STEP,6,6);
     }
 
 }

--- a/backend/src/main/java/com/example/backend/physics/objs/GizmoBall.java
+++ b/backend/src/main/java/com/example/backend/physics/objs/GizmoBall.java
@@ -11,25 +11,26 @@ import org.jbox2d.dynamics.BodyType;
 import org.jbox2d.dynamics.FixtureDef;
 
 import java.awt.*;
+
 /**
  * 球类
  * 包括但不限于这个类，所以的组件类中的drawMe都是JPanel测试用类，只有我一个人会用到，其他人不用看
- * */
-public class GizmoBall extends WorldObjects{
+ */
+public class GizmoBall extends WorldObjects {
 
     float r;
     Color color = Color.cyan;
 
     //在我的理解中，反射得到的构造函数是这个
-    public GizmoBall(Integer id, Float x, Float y){
+    public GizmoBall(Integer id, Float x, Float y) {
         this.objectId = id;
         this.worldX = x;
         this.worldY = y;
-        this.r = (float) (WorldConstant.LENGTH / 2.0);
+        this.r = WorldConstant.LENGTH / 2.0f;
         initBallInWorld();
     }
 
-    public GizmoBall(float worldX, float worldY, float r){
+    public GizmoBall(float worldX, float worldY, float r) {
         this.worldX = worldX;
         this.worldY = worldY;
         this.r = r;
@@ -37,23 +38,23 @@ public class GizmoBall extends WorldObjects{
         initBallInWorld();
     }
 
-    public int getPixelX(){
-        int pixelX = WorldPlace.mile2Pixel(body.getPosition().x-r);
+    public int getPixelX() {
+        int pixelX = WorldPlace.mile2Pixel(body.getPosition().x - r);
         return pixelX;
     }
 
-    public int getPixelY(){
-        int pixelY = WorldPlace.toPixelHeight(body.getPosition().y+r);
+    public int getPixelY() {
+        int pixelY = WorldPlace.toPixelHeight(body.getPosition().y + r);
         return pixelY;
     }
 
-    public int getDiameter(){
-        return WorldPlace.mile2Pixel(r*2);
+    public int getDiameter() {
+        return WorldPlace.mile2Pixel(r * 2);
     }
 
-    private void initBallInWorld(){
+    private void initBallInWorld() {
         BodyDef bd = new BodyDef();
-        bd.position = new Vec2(worldX,worldY);
+        bd.position = new Vec2(worldX, worldY);
         bd.type = BodyType.DYNAMIC;
 
         FixtureDef fd = new FixtureDef();
@@ -69,53 +70,52 @@ public class GizmoBall extends WorldObjects{
     }
 
     @Override
-    public void shrink(){
-        if(isSizeLarge){
+    public void shrink() {
+        if (isSizeLarge) {
             isSizeLarge = false;
             Shape bodyShape = body.getFixtureList().getShape();
-            if(bodyShape.getType() == ShapeType.CIRCLE){
+            if (bodyShape.getType() == ShapeType.CIRCLE) {
                 bodyShape.setRadius(1);
                 this.r = (float) (WorldConstant.LENGTH / 2.0);
             }
 
         }
-        //???
+
         body.setAwake(true);
     }
 
     @Override
-    public void magnify(){
-        if(!isSizeLarge){
+    public void magnify() {
+        if (!isSizeLarge) {
             isSizeLarge = true;
             Shape bodyShape = body.getFixtureList().getShape();
-            if(bodyShape.getType() == ShapeType.CIRCLE){
+            if (bodyShape.getType() == ShapeType.CIRCLE) {
                 bodyShape.setRadius(WorldConstant.LENGTH);
                 this.r = WorldConstant.LENGTH;
             }
         }
-        //???
         body.setAwake(true);
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         return "Ball" + "#"
-                +"{" + objectId + "}" + "#"
-                +"{" + worldX + "}" + "#"
-                +"{" + worldY + "}" + "#"
-                +"{" + isSizeLarge + "}" + "#"
-                +"{" + body.getLinearVelocity().x + "}" + "#"
-                +"{" + body.getLinearVelocity().y + "}";
+                + objectId + "#"
+                + (body.getPosition().x / WorldConstant.LENGTH) + "#"
+                + ((WorldConstant.HIGHT - body.getPosition().y) / WorldConstant.LENGTH) + "#"
+                + isSizeLarge + "#"
+                + (body.getLinearVelocity().x / WorldConstant.LENGTH) + "#"
+                + (body.getLinearVelocity().y / WorldConstant.LENGTH);
     }
 
     //修改物体的物理学Type，非材质Type
-    public void SetBallType(BodyType b_type){
+    public void SetBallType(BodyType b_type) {
         body.m_type = b_type;
     }
 
     @Override
     public void drawMe(Graphics2D g) {
         g.setColor(color);
-        g.fillOval(this.getPixelX(),this.getPixelY(),this.getDiameter(),this.getDiameter());
+        g.fillOval(this.getPixelX(), this.getPixelY(), this.getDiameter(), this.getDiameter());
     }
 }

--- a/web/src/assets/script/Baffle.js
+++ b/web/src/assets/script/Baffle.js
@@ -23,16 +23,31 @@ export class Baffle extends GimzoComponent{
     add_listening_events(){
         const store = this.gameMap.store;
         const canvas = this.gameMap.ctx.canvas;
+        let socket = this.gameMap.store.state.layout.socket;
         canvas.addEventListener("keydown", e=>{
             console.log(e);
             if(store.state.layout.status === 'game'){
-                if(e.key ==='ArrowLeft'){
-                    if(this.c - this.velocity * this.timedelta / 1000 >= this.limit[0]){    
-                        this.c -= this.velocity * this.timedelta / 1000;
+                if(this.limit[0] === 0){
+                    if(e.key ==='ArrowLeft'){
+                       if(this.c - this.velocity * this.timedelta / 1000 >= this.limit[0]){    
+                            this.c -= this.velocity * this.timedelta / 1000;
+                            socket.send();
+                        }
+                    } else if(e.key === 'ArrowRight'){
+                        if(this.c + this.velocity * this.timedelta / 1000 < this.limit[1]){
+                            this.c += this.velocity * this.timedelta / 1000;
+                        }
                     }
-                } else if(e.key === 'ArrowRight'){
-                    if(this.c + this.velocity * this.timedelta / 1000 < this.limit[1]){
-                        this.c += this.velocity * this.timedelta / 1000;
+                } else {
+                    if(e.key ==='A'){
+                       if(this.c - this.velocity * this.timedelta / 1000 >= this.limit[0]){    
+                            this.c -= this.velocity * this.timedelta / 1000;
+                            socket.send();
+                        }
+                    } else if(e.key === 'D'){
+                        if(this.c + this.velocity * this.timedelta / 1000 < this.limit[1]){
+                            this.c += this.velocity * this.timedelta / 1000;
+                        }
                     }
                 }
             }

--- a/web/src/assets/script/Ball.js
+++ b/web/src/assets/script/Ball.js
@@ -16,6 +16,10 @@ export class Ball extends GimzoShape{
         this.image.src = this.gameMap.store.state.icon.ball_icon;
     }
 
+    set_position(x , y) {
+        this.r = y;
+        this.c = x;
+    }
 
     /**
      * 更新函数
@@ -23,14 +27,13 @@ export class Ball extends GimzoShape{
      * 2、当处于游戏模式的时候位置发生变化
      */
     update(){
-        this.render()
+        this.render();
     }
-
+    
     /**
      * 绘制函数
      */
     render(){
-        // console.log(this.image);
         const ctx = this.gameMap.ctx;
         const L = this.gameMap.L;
         ctx.drawImage(this.image, this.c * L, this.r * L, L * this.size, L * this.size);

--- a/web/src/assets/script/GimzoComponent.js
+++ b/web/src/assets/script/GimzoComponent.js
@@ -1,0 +1,46 @@
+import { GimzoObject } from "./GimzoObject";
+import { Cell } from "./Cell";
+
+export class GimzoComponent extends GimzoObject{
+    constructor(gameMap, c, r){
+        super();
+        this.gameMap = gameMap;
+        this.c = c;
+        this.r = r;
+
+        this.cells = [];
+        this.cells.push(new Cell(r ,c));
+        this.x = this.r * this.gameMap.L;
+        this.y = this.c * this.gameMap.L;
+        this.eps = 0.1;
+    }
+
+
+    start(){
+        for(let cell of this.cells){
+            this.gameMap.set_position([cell.c,cell.r], this);
+        }
+    }
+
+    on_destroy(){
+        for(let cell of this.cells){
+            this.gameMap.set_position([cell.c,cell.r], undefined);
+        }
+
+        let socket = this.gameMap.store.state.layout.socket;
+        socket.send("delete " + this.id);
+    }
+
+    shrink(){
+        //缩小
+    }
+
+    magnify(){
+        //放大
+    }
+
+    rotate(){
+        //旋转
+    }
+
+}

--- a/web/src/assets/script/GimzoShape.js
+++ b/web/src/assets/script/GimzoShape.js
@@ -1,0 +1,42 @@
+import { GimzoComponent } from "./GimzoComponent";
+import { Cell } from "./Cell";
+
+export class GimzoShape extends GimzoComponent {
+    constructor(gameMap, c, r){
+        super(gameMap, c, r);
+        this.size = 1;
+    }
+
+    magnify(){
+        let new_cells = [];
+        let dx = [0, 1, 1];
+        let dy = [1, 0, 1];
+        let components = this.gameMap.components;
+        for(let i in dx){
+            if(components[[this.c + dx[i], this.r + dy[i]]] != null) {
+                return false;
+            }
+            let cell = new Cell(this.r + dx[i], this.c + dy[i]);
+            new_cells.push(cell);
+            
+            components[[this.c + dx[i], this.r + dy[i]]] = this;
+        }
+        this.cells = this.cells.concat(new_cells);
+        this.size = 2;
+
+        let socket = this.gameMap.store.state.layout.socket;
+        socket.send("magnify " + this.id);
+    }
+
+    shrink(){
+        let components = this.gameMap.components;
+        for(let i = 1; i < this.cells.length; i++){
+            let cell = this.cells[i];
+            delete components[[cell.c,cell.r]];
+        }
+        this.cells.splice(1,3);
+        this.size = 1;
+        let socket = this.gameMap.store.state.layout.socket;
+        socket.send("shrink " + this.id);
+    }
+}

--- a/web/src/components/GameDesignBar.vue
+++ b/web/src/components/GameDesignBar.vue
@@ -14,9 +14,11 @@ export default {
     methods: {
         game(){
             this.$store.commit('updateStatus', 'game');
+            this.$store.state.layout.socket.send("startGame");
         },
         layout(){
             this.$store.commit('updateStatus', 'layout');
+            this.$store.state.layout.socket.send("endGame");
         }
     },
 }

--- a/web/src/views/LayoutView.vue
+++ b/web/src/views/LayoutView.vue
@@ -49,7 +49,15 @@ export default {
       this.$store.commit("updateSocket", this.socket);
     };
     this.socket.onmessage = msg =>{
-      console.log(msg);
+      if(this.$store.state.layout.status ==='layout'){
+        //文件导入
+      } else {
+        // console.log(msg.data);
+        const msgs = msg.data.split("#");
+        const x = msgs[2];
+        const y = msgs[3];
+        this.$store.state.layout.gameMap.ball.set_position(x, y);
+      }
     };
     this.socket.onclose = () => {
       console.log("disconnected!");


### PR DESCRIPTION
现在问题很多，总结下来下一阶段分工如下：

文件类

- 前端界面上没有保存导出的按钮，需要完成保存和导入（dyh，GameDesign.js）
  - 按钮需要在游戏模式禁用，只有布局模式可以保存和导入
  - 保存和导入需要和后端结合
- 前端js导入文件信息初始化布局（dyh,LayoutView.vue)
- 前端js的构造函数的修改（dyh,所有有旋转类的js）
- 后端打开文件传入信息（yy,FileController,FileService,WebSocket)

物理类

- 后端组件黑洞(Blackhole)、挡板(Baffle)、轨道(StraightPipe,BendPipe)没实现（wxt）
  - ![image-20221122175344354](http://typora-yy.oss-cn-hangzhou.aliyuncs.com/img/image-20221122175344354.png)
- 后端组件的球体、三角形、正方体的放大、旋转有问题（wxt，yy）
  - 旋转后会穿模![image-20221122175525641](http://typora-yy.oss-cn-hangzhou.aliyuncs.com/img/image-20221122175525641.png)
- 三角型的初始化角度
- 后端组件的toString方法重构
  - Ball的toString方法（我已经改好了，yy)
  - Baffle的toString方法（wxt）
- worldManager清空（wxt）
- WorldManager获得单独一个球，两个挡板（左挡板，右挡板）